### PR TITLE
Update libraries and frameworks to latest versions

### DIFF
--- a/core-java/collectionops/pom.xml
+++ b/core-java/collectionops/pom.xml
@@ -11,12 +11,12 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.4</version>
+			<version>4.5</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.google.guava</groupId>
 		    <artifactId>guava</artifactId>
-		    <version>31.0.1-jre</version>
+		    <version>31.1-jre</version>
 		</dependency>
 
 

--- a/core-java/jackson/jackson/pom.xml
+++ b/core-java/jackson/jackson/pom.xml
@@ -17,13 +17,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.3</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.13.3</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.1</version>
+		<version>2.7.3</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.pratik</groupId>

--- a/mapstruct/pom.xml
+++ b/mapstruct/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <org.mapstruct.version>1.4.2.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
         <org.projectlombok.version>1.18.24</org.projectlombok.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>


### PR DESCRIPTION
Related to #133

Updates dependencies across various modules to their latest versions.

- **Core Java Collections Operations (`core-java/collectionops/pom.xml`):**
  - Updates `org.apache.commons:commons-collections4` to version 4.5.
  - Updates `com.google.guava:guava` to version 31.1-jre.
- **Core Java Jackson (`core-java/jackson/jackson/pom.xml`):**
  - Updates `com.fasterxml.jackson.core:jackson-databind` and `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` to version 2.14.1.
- **GraphQL Module (`graphql/pom.xml`):**
  - Updates Spring Boot version to 2.7.3.
- **MapStruct Module (`mapstruct/pom.xml`):**
  - Updates MapStruct version to 1.5.2.Final.
  - Maintains Lombok version at 1.18.24, aligning with the initial version before the update.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GitHub-BR-Work/code-examples/issues/133?shareId=0d75f171-c624-429c-984e-edac689fc0fe).