### PR TITLE
Update Java Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ This repo contains example projects which show how to use different (not only) J
 The examples are usually accompanied by a blog post on [https://reflectoring.io](https://reflectoring.io).
 
 See the READMEs in each subdirectory of this repo for more information on each module.
+
+## Dependency Updates
+
+- Updated Java dependencies in `apache-http-client/pom.xml` to their latest versions.
+- Verified that DotNet is not applicable to this repository.

--- a/apache-http-client/pom.xml
+++ b/apache-http-client/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <junit-jupiter.version>5.10.2</junit-jupiter.version>
-        <apache-http-client.version>5.3.1</apache-http-client.version>
+        <apache-http-client.version>5.3.3</apache-http-client.version>
     </properties>
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5 -->
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5-reactive</artifactId>
-            <version>5.2.4</version>
+            <version>5.2.6</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.reactivex.rxjava3/rxjava -->


### PR DESCRIPTION
Related to #135

Updates Java dependencies in `apache-http-client/pom.xml` and adds update details to `README.md`.

- Updates the version of `apache-http-client` to `5.3.3` and `httpcore5-reactive` to `5.2.6` in `apache-http-client/pom.xml` to align with the latest stable versions available.
- Adds a new section titled "Dependency Updates" in `README.md` detailing the Java dependencies updates and the verification that DotNet is not applicable to this repository.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GitHub-BR-Work/code-examples/issues/135?shareId=dd3e0554-ea23-4013-906e-774c3e621f51).