### PR TITLE
Fix code scanning alert no. 19: Server-side request forgery

### DIFF
--- a/nodejs/axios/serversideapp/index.js
+++ b/nodejs/axios/serversideapp/index.js
@@ -149,6 +149,12 @@ app.get('/products/:productName/inventory', (request, response) => {
 
   const productName = request.params.productName
 
+  const allowedProductNames = ['Television', 'Washing Machine', 'Laptop']
+
+  if (!allowedProductNames.includes(productName)) {
+    return response.status(400).send({ error: 'Invalid product name' })
+  }
+
   const productApiResponse = axios.get(`http://localhost:3002/products/${productName}`)
   const inventoryApiResponse = axios.get(`http://localhost:3002/products/${productName}/itemsInStock`)
 


### PR DESCRIPTION
Fixes [https://github.com/GitHub-BR-Work/code-examples/security/code-scanning/19](https://github.com/GitHub-BR-Work/code-examples/security/code-scanning/19)

To fix the SSRF vulnerability, we need to ensure that the `productName` parameter is validated and sanitized before it is used to construct the URL. One way to achieve this is by using a whitelist of allowed product names. This approach ensures that only predefined, safe values are used in the URL.

1. Create a whitelist of allowed product names.
2. Check if the `productName` from the user input is in the whitelist.
3. If it is, proceed with the request; otherwise, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
