### PR TITLE
Potential fix for code scanning alert no. 70: Missing rate limiting

### DIFF
--- a/nodejs/cicd-nodejs/package.json
+++ b/nodejs/cicd-nodejs/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "express": "^4.19.2",
     "jest": "^29.6.2",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "express-rate-limit": "^7.4.1"
   }
 }

--- a/nodejs/cicd-nodejs/src/app.js
+++ b/nodejs/cicd-nodejs/src/app.js
@@ -1,6 +1,17 @@
 const express = require("express");
 const path = require("path");
+const RateLimit = require("express-rate-limit");
 const app = express();
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+// apply rate limiter to all requests
+app.use(limiter);
+
 app.use(express.static("public"));
 
 app.get("/test", (_req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/GitHub-BR-Work/code-examples/security/code-scanning/70](https://github.com/GitHub-BR-Work/code-examples/security/code-scanning/70)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will ensure that the number of requests to the server is controlled, preventing potential denial-of-service attacks.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `nodejs/cicd-nodejs/src/app.js` file.
3. Set up a rate limiter with a reasonable configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to all routes in the application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
